### PR TITLE
Splice list fix (This fixes issue #1 on shott/EnumSlider)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+test/javasource/
+test/deployment/
+test/.classpath
+test/.project
+*.launch
+*.tmp
+*.lock
+test/zip Progress Bar.bat
+.idea/


### PR DESCRIPTION
I believe that I have added a simple one-line (plus opening and closing brackets) change to EnumSlider.js that sorts spliceList into increasing numerical order of the indexes of this.slideEnum that should be removed.

I believe that this removes any order-dependence on the comma-separated string this.enumExceptions and, I believe, resolves the issue that I reported for this Widget as issue #1.

Note, I also apparently accidentally did a revert of "Added .gitignore".  That must have been my pilot error.  However, by doing a second revert of that action, I believe that it has been restored to its original condition.  A apologize for that error and will hope to avoid such clumsiness in the future.

This was my first use of trying to add a branch to fix a problem in the Mendix GitHub set of widgets.  If I did anything wrong or inappropriate, please do not hesitate to contact me directly at shott@stanford.edu.

Thanks,

John
